### PR TITLE
Fix Test de travis

### DIFF
--- a/l10n_es_aeat/tests/test_l10n_es_aeat_mod_base.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat_mod_base.py
@@ -46,6 +46,7 @@ class TestL10nEsAeatModBase(common.TransactionCase):
             'currency_id': self.ref('base.EUR'),
             'transfer_account_id': self.chart.transfer_account_id.id,
         })
+        wizard.onchange_chart_template_id()
         wizard.execute()
         return True
 


### PR DESCRIPTION
He añadido una modificación al test base de l10n_es_aeat que heredan el resto de modelos para realizar sus tests. 

He probado a inicializar una nueva base de datos de cero en local directamente y antes me salía el mismo error en la ejecución y ahora ya no me ha salido al volver a inicializar de nuevo la base de datos con este código cambiado.

A ver si funciona con lo de Travis